### PR TITLE
Update unmockedModulePathPatterns in examples/react/package.json

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -8,6 +8,6 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/preprocessor.js",
-    "unmockedModulePathPatterns": ["<rootDir>/node_modules/react"]
+    "unmockedModulePathPatterns": ["react"]
   }
 }


### PR DESCRIPTION
["<rootDir>/node_modules/react"] was causing a TypeError when the test was run where the CallbackQueue inside the ReactUpdates.js file didn't have a getPooled method. Changing the value to ["react"] resolved this issue.
